### PR TITLE
ci(workflow): temporarily remove CodeQL lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -90,45 +90,6 @@ jobs:
           fi
           echo "✅ Code is gofumpt!"
 
-  analyze-go:
-    runs-on: ubuntu-22.04
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Find changed go files
-        id: changed-go-files
-        uses: tj-actions/changed-files@v45.0.4
-        with:
-          files: |
-            **/*.go
-            go.mod
-            go.sum
-
-      - name: Setup Go environment
-        uses: actions/setup-go@v5.2.0
-        with:
-          go-version: "1.23"
-          cache: false
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: "go"
-
-      - name: Autobuild project
-        uses: github/codeql-action/autobuild@v3
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
-
   lint-shell:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
Temporarily remove CodeQL lint job. The CodeQL lint job fails consistently because the repository is private for now, and Advanced Security is not enabled.