### PR TITLE
feat(delegators): add --hrp flag for Bech32 address delegators

### DIFF
--- a/pkg/delegators/enhancer.go
+++ b/pkg/delegators/enhancer.go
@@ -1,0 +1,87 @@
+package delegators
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/teambenny/goetl"
+	"github.com/teambenny/goetl/etldata"
+
+	"cosmossdk.io/log"
+
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+)
+
+type addressEnhancer struct {
+	prefixes []string
+	logger   log.Logger
+	keys     []string
+	name     string
+}
+
+// NewAddressEnhancer returns a new processor that enrich the data with addresses with the given prefixes.
+func NewAddressEnhancer(prefixes []string, logger log.Logger) (goetl.Processor, error) {
+	keys := make([]string, len(prefixes))
+	for i, prefix := range prefixes {
+		keys[i] = fmt.Sprintf("delegator-%s-address", prefix)
+	}
+
+	return &addressEnhancer{
+		prefixes: prefixes,
+		logger:   logger,
+		keys:     keys,
+		name:     fmt.Sprintf("AddressEnhancer(%s)", strings.Join(prefixes, ",")),
+	}, nil
+}
+
+func (p *addressEnhancer) ProcessData(payload etldata.Payload, outputChan chan etldata.Payload, killChan chan error) {
+	delegation := Delegation{}
+	if err := payload.Parse(&delegation); err != nil {
+		p.logger.Error(err.Error())
+		killChan <- err
+		return
+	}
+	data, err := payload.Objects()
+	if err != nil {
+		p.logger.Error(err.Error())
+		killChan <- err
+		return
+	}
+
+	for _, datum := range data {
+		for idx, prefix := range p.prefixes {
+			addr, err := convertAndEncodeMust(prefix, delegation.DelegatorNativeAddr)
+			if err != nil {
+				p.logger.Error(err.Error())
+				killChan <- err
+				return
+			}
+			datum[p.keys[idx]] = addr
+		}
+	}
+
+	json, err := etldata.NewJSON(data)
+	if err != nil {
+		p.logger.Error(err.Error())
+		killChan <- err
+		return
+	}
+
+	outputChan <- json
+}
+
+func (p *addressEnhancer) Finish(_ chan etldata.Payload, _ chan error) {
+}
+
+func (p *addressEnhancer) String() string {
+	return p.name
+}
+
+func convertAndEncodeMust(hrp string, bech string) (string, error) {
+	_, bytes, err := bech32.DecodeAndConvert(bech)
+	if err != nil {
+		return "", err
+	}
+
+	return bech32.ConvertAndEncode(hrp, bytes)
+}

--- a/pkg/delegators/payload.go
+++ b/pkg/delegators/payload.go
@@ -3,9 +3,6 @@ package delegators
 type Delegation struct {
 	ChainName           string `json:"chain_name"`
 	DelegatorNativeAddr string `json:"delegator_native_addr"`
-	DelegatorCosmosAddr string `json:"delegator_cosmos_addr"`
-	DelegatorAxoneAddr  string `json:"delegator_axone_addr"`
-
-	ValidatorAddr string `json:"validator_addr"`
-	Shares        string `json:"shares"`
+	ValidatorAddr       string `json:"validator_addr"`
+	Shares              string `json:"shares"`
 }

--- a/pkg/delegators/reader.go
+++ b/pkg/delegators/reader.go
@@ -18,7 +18,6 @@ import (
 	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/bech32"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
@@ -85,8 +84,6 @@ func (r *delegatorsReader) ProcessData(_ etldata.Payload, outputChan chan etldat
 			payload := Delegation{
 				ChainName:           r.chainName,
 				DelegatorNativeAddr: delegation.DelegatorAddress,
-				DelegatorCosmosAddr: convertAndEncodeMust("cosmos", delegation.DelegatorAddress),
-				DelegatorAxoneAddr:  convertAndEncodeMust("axone", delegation.DelegatorAddress),
 				ValidatorAddr:       delegation.ValidatorAddress,
 				Shares:              delegation.Shares.String(),
 			}
@@ -138,20 +135,6 @@ func IterateAllAddresses(ctx context.Context, bankKeeper bankkeeper.BaseKeeper, 
 	})
 
 	return err
-}
-
-func convertAndEncodeMust(hrp string, bech string) string {
-	_, bytes, err := bech32.DecodeAndConvert(bech)
-	if err != nil {
-		panic(err)
-	}
-
-	encoded, err := bech32.ConvertAndEncode(hrp, bytes)
-	if err != nil {
-		panic(err)
-	}
-
-	return encoded
 }
 
 func guessPrefixFromValoper(valoper string) (string, error) {


### PR DESCRIPTION
Add `--hrp` flag to generate Bech32-converted addresses for delegators.