### PR TITLE
build(release): improve release configuration

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,12 +4,31 @@ branches:
 plugins:
   - - "@semantic-release/commit-analyzer"
     - preset: conventionalcommits
+      releaseRules:
+        - type: build
+          scope: deps
+          release: patch
+        - type: build
+          scope: deps-dev
+          release: patch
+        - type: refactor
+          release: patch
+        - type: style
+          release: patch
+        - type: ci
+          release: patch
+        - type: chore
+          release: patch
+        - type: docs
+          release: patch
+        - breaking: true
+          release: major
   - - "@semantic-release/release-notes-generator"
     - preset: conventionalcommits
   - - "@semantic-release/changelog"
     - changelogFile: CHANGELOG.md
-      changelogTitle: "# Axone Wallet Extractor Changelog"
-  - - "@google/semantic-release-replace-plugin"
+      changelogTitle: "# Cosmos Extractor changelog"
+  - - "semantic-release-replace-plugin"
     - replacements:
         - files: [version]
           from: ^.+$


### PR DESCRIPTION
Improve the release process by configuring [conventional commits](https://github.com/semantic-release/commit-analyzer) and replacing the deprecated `@google/semantic-release-replace-plugin` with [semantic-release-replace-plugin](https://github.com/jpoehnelt/semantic-release-replace-plugin).